### PR TITLE
草生えるボタンのカウント修正

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -72,19 +72,13 @@ export default function Home() {
         type: REACTION_TYPE,
       },
     }),
-    update(cache, { data: { createReaction } }) {
-      const existing = cache.readQuery({ query: GET_ALL_POSTS }) as any;
-      if (!existing) return;
-      const newPosts = existing.allPosts.map((post: any) =>
-        post.id === createReaction.postId
-          ? { ...post, reactions: [...post.reactions, createReaction] }
-          : post
-      );
-      cache.writeQuery({
+    refetchQueries: [
+      {
         query: GET_ALL_POSTS,
-        data: { allPosts: newPosts },
-      });
-    },
+        variables: { limit: POSTS_PER_PAGE, offset: page * POSTS_PER_PAGE },
+      },
+    ],
+    awaitRefetchQueries: true,
   });
 
   const handleReaction = async (postId: number) => {


### PR DESCRIPTION
ページ分けをしたことでページネーション付きのクエリ では毎回 variables: { limit, offset } を指定してデータをフェッチしているため、Apollo Client の内部キャッシュにも「GET_ALL_POSTS + その変数」がキーとして保存されているが、 readQuery/writeQuery を使うときに変数を同じように渡していなかったため、キャッシュがそもそも見つからず（ヒットせず）、アップデート処理がスキップされていた。
結果としてリアクションを送信しても、キャッシュ上の投稿オブジェクトに反映されず、画面にも変化が出なかった